### PR TITLE
Keep track of inheritance graph

### DIFF
--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -192,6 +192,12 @@ class PropertyMetaclass(type):
         # Save the class in the registry
         newcls._REGISTRY[name] = newcls
 
+        # Save the original class inheritance graph
+        newcls._CLS_GRAPH[name] = set()
+        for cls in bases:
+            if cls.__name__ in newcls._REGISTRY:
+                newcls._CLS_GRAPH[name].add(cls.__name__)
+
         return newcls
 
     def __call__(cls, *args, **kwargs):
@@ -249,6 +255,7 @@ class HasProperties(with_metaclass(PropertyMetaclass, object)):
 
     _defaults = dict()
     _REGISTRY = dict()
+    _CLS_GRAPH = dict()
 
     def __init__(self, **kwargs):
         # Set the keyword arguments with change notifications


### PR DESCRIPTION
The idea behind this piece of work is to preserve information about the explicit (vs. implicit) inheritance relationships between classes.

As the metaclass constructs HasProperties subclasses, it enters the baked-in inheritance structure into a dictionary that is stored on the class. This makes it possible to re-construct the data object inheritance path in its original form. This is useful for displaying the class structure (i.e., UML graphs), but also for replicating / reproducing the inheritance when writing translation libraries for data objects.

TODO:
- [ ] Possibly switch to using `collections.OrderedDict`, such that the creation order is preserved
- [ ] Possibly switch to a `list` instead of a `set`, to preserve precedence (`super`/`__mro__` order)