### PR TITLE
Allow private properties

### DIFF
--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -120,7 +120,7 @@ class PropertyMetaclass(type):
         for key, handler in iteritems(observer_dict):
             classdict[key] = handler.func
 
-        # Determine if private properties should be documented
+        # Determine if private properties should be documented or just public
         _doc_private = False
         for base in reversed(bases):
             _doc_private = getattr(base, '_doc_private', _doc_private)
@@ -135,7 +135,15 @@ class PropertyMetaclass(type):
             documented_props = sorted(p for p in _props if p[0] != '_')
 
         # Order the properties for the docs (default is alphabetical)
-        _doc_order = classdict.pop('_doc_order', None)
+        _doc_order = None
+        for base in reversed(bases):
+            _doc_order = getattr(base, '_doc_order', _doc_order)
+            if (
+                    not isinstance(_doc_order, (list, tuple)) or
+                    sorted(list(_doc_order)) != documented_props
+            ):
+                _doc_order = None
+        _doc_order = classdict.get('_doc_order', _doc_order)
         if _doc_order is None:
             _doc_order = documented_props
         elif not isinstance(_doc_order, (list, tuple)):

--- a/properties/base/base.py
+++ b/properties/base/base.py
@@ -99,10 +99,6 @@ class PropertyMetaclass(type):
 
         # Ensure prop names are valid and overwrite properties with @property
         for key, prop in iteritems(prop_dict):
-            if key[0] == '_':
-                raise AttributeError(
-                    'Property names cannot be private: {}'.format(key)
-                )
             if isinstance(prop, basic.Renamed) and prop.new_name not in _props:
                 raise TypeError('Invalid new name for renamed property: '
                                 '{}'.format(prop.new_name))
@@ -124,15 +120,29 @@ class PropertyMetaclass(type):
         for key, handler in iteritems(observer_dict):
             classdict[key] = handler.func
 
+        # Determine if private properties should be documented
+        _doc_private = False
+        for base in reversed(bases):
+            _doc_private = getattr(base, '_doc_private', _doc_private)
+        _doc_private = classdict.get('_doc_private', _doc_private)
+
+        if not isinstance(_doc_private, bool):
+            raise AttributeError('_doc_private must be a boolean')
+
+        if _doc_private:
+            documented_props = sorted(_props)
+        else:
+            documented_props = sorted(p for p in _props if p[0] != '_')
+
         # Order the properties for the docs (default is alphabetical)
         _doc_order = classdict.pop('_doc_order', None)
         if _doc_order is None:
-            _doc_order = sorted(_props)
+            _doc_order = documented_props
         elif not isinstance(_doc_order, (list, tuple)):
             raise AttributeError(
                 '_doc_order must be a list of property names'
             )
-        elif sorted(list(_doc_order)) != sorted(_props):
+        elif sorted(list(_doc_order)) != documented_props:
             raise AttributeError(
                 '_doc_order must be unspecified or contain ALL property names'
             )
@@ -140,11 +150,13 @@ class PropertyMetaclass(type):
         # Sort props into required, optional, and immutable
         doc_str = classdict.get('__doc__', '')
         req = [key for key in _doc_order
-               if getattr(_props[key], 'required', False)]
+               if key[0] != '_' and getattr(_props[key], 'required', False)]
         opt = [key for key in _doc_order
-               if not getattr(_props[key], 'required', True)]
+               if key[0] != '_' and not getattr(_props[key], 'required', True)]
         imm = [key for key in _doc_order
-               if not hasattr(_props[key], 'required')]
+               if key[0] != '_' and not hasattr(_props[key], 'required')]
+        priv = [key for key in _doc_order
+                if key[0] == '_']
 
         # Build the documentation based on above sorting
         if req:
@@ -158,6 +170,10 @@ class PropertyMetaclass(type):
         if imm:
             doc_str += '\n\n**Other Properties:**\n\n' + '\n'.join(
                 ('* ' + _props[key].sphinx() for key in imm)
+            )
+        if priv:
+            doc_str += '\n\n**Private Properties:**\n\n' + '\n'.join(
+                ('* ' + _props[key].sphinx() for key in priv)
             )
         classdict['__doc__'] = doc_str
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,9 +27,6 @@ class TestBasic(unittest.TestCase):
             properties.GettableProperty('bad kwarg', defualt=5)
         with self.assertRaises(TypeError):
             properties.Property('bad kwarg', required=5)
-        with self.assertRaises(AttributeError):
-            class PrivateProperty(properties.HasProperties):
-                _secret = properties.GettableProperty('secret prop')
 
         class GettablePropOpt(properties.HasProperties):
             mygp = properties.GettableProperty('gettable prop')
@@ -102,7 +99,7 @@ class TestBasic(unittest.TestCase):
             myprop2 = properties.Property('empty property')
             myprop3 = properties.Property('empty property')
 
-        assert WithDocOrder().__doc__ == (
+        ordered_doc = (
             '\n\n**Required Properties:**\n\n'
             '* **myprop1** (:class:`Property <properties.Property>`): '
             'empty property\n'
@@ -111,6 +108,28 @@ class TestBasic(unittest.TestCase):
             '* **myprop2** (:class:`Property <properties.Property>`): '
             'empty property'
         )
+        assert WithDocOrder().__doc__ == ordered_doc
+
+        class SameDocOrder(WithDocOrder):
+            _my_private_prop = properties.Property('empty property')
+
+        assert SameDocOrder().__doc__ == ordered_doc
+
+        class DifferentDocOrder(WithDocOrder):
+            myprop4 = properties.Property('empty property')
+
+        unordered_doc = (
+            '\n\n**Required Properties:**\n\n'
+            '* **myprop1** (:class:`Property <properties.Property>`): '
+            'empty property\n'
+            '* **myprop2** (:class:`Property <properties.Property>`): '
+            'empty property\n'
+            '* **myprop3** (:class:`Property <properties.Property>`): '
+            'empty property\n'
+            '* **myprop4** (:class:`Property <properties.Property>`): '
+            'empty property'
+        )
+        assert DifferentDocOrder().__doc__ == unordered_doc
 
         class NoMoreDocOrder(WithDocOrder):
             _doc_order = None


### PR DESCRIPTION
This removes the restriction against private properties. By default, these properties are undocumented, but they may be added to the docs with the `_doc_private = True` class attribute.

This PR also slightly modifies `_doc_order` - this attribute is now kept on the class and may be used for subclasses if their properties do not change.