### PR TITLE
python 3.6 in testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ python:
   - 3.6
 sudo: false
 
-matrix:
-  allow_failures:
-    - python: 3.6
-
 addons:
   apt:
     packages:


### PR DESCRIPTION
It looks like python 3.6 is passing, and since it is becoming much more standard, the testing could enforce that properties passes on 3.6 as well.