### PR TITLE
Remove defunct Quantified Code badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,6 @@ properties
     :target: https://codecov.io/gh/aranzgeo/properties
     :alt: Code coverage
 
-.. image:: https://www.quantifiedcode.com/api/v1/project/f79abeb2219a4a2d9b683f8d57bcdab5/badge.svg
-    :target: https://www.quantifiedcode.com/app/project/f79abeb2219a4a2d9b683f8d57bcdab5
-    :alt: Code issues
-
 
 Overview Video
 --------------


### PR DESCRIPTION
Quantified code has shut down, and the badge is now a broken link / image.
Also, this fails the docs tests.