### PR TITLE
Remove _class_default from containers

### DIFF
--- a/properties/base/containers.py
+++ b/properties/base/containers.py
@@ -192,7 +192,7 @@ class Tuple(basic.Property):
     """
 
     class_info = 'a tuple'
-    _class_default = tuple
+    _class_container = tuple
 
     def __init__(self, doc, prop=None, **kwargs):
         if prop is not None:
@@ -283,7 +283,7 @@ class Tuple(basic.Property):
         This returns a copy of the container to prevent unwanted sharing of
         pointers.
         """
-        if not self.coerce and not isinstance(value, self._class_default):
+        if not self.coerce and not isinstance(value, self._class_container):
             self.error(instance, value)
         if self.coerce and not isinstance(value, CONTAINERS):
             value = [value]
@@ -293,7 +293,7 @@ class Tuple(basic.Property):
                 out += [self.prop.validate(instance, val)]
             except ValueError:
                 self.error(instance, val, extra='This item is invalid.')
-        return self._class_default(out)
+        return self._class_container(out)
 
     def assert_valid(self, instance, value=None):
         """Check if tuple and contained properties are valid"""
@@ -333,7 +333,7 @@ class Tuple(basic.Property):
             return None
         output_list = [self.prop.deserialize(val, **kwargs)
                        for val in value]
-        return self._class_default(output_list)
+        return self._class_container(output_list)
 
     def equal(self, value_a, value_b):
         try:
@@ -400,7 +400,7 @@ class List(Tuple):
     """
 
     class_info = 'a list'
-    _class_default = list
+    _class_container = list
 
     @property
     def observe_mutations(self):
@@ -417,7 +417,7 @@ class List(Tuple):
         value = super(List, self).validate(instance, value)
         if not self.observe_mutations:
             return value
-        value = OBSERVABLE[self._class_default](value)
+        value = OBSERVABLE[self._class_container](value)
         value._name = self.name
         value._instance = instance
         return value
@@ -458,7 +458,7 @@ class Set(List):
     """
 
     class_info = 'a set'
-    _class_default = set
+    _class_container = set
 
     def equal(self, value_a, value_b):
         try:
@@ -507,7 +507,7 @@ class Dictionary(basic.Property):
     """
 
     class_info = 'a dictionary'
-    _class_default = dict
+    _class_container = dict
 
     @property
     def observe_mutations(self):
@@ -567,7 +567,7 @@ class Dictionary(basic.Property):
     def validate(self, instance, value):
         if not isinstance(value, dict):
             self.error(instance, value)
-        out = self._class_default()
+        out = self._class_container()
         for key, val in iteritems(value):
             if self.key_prop:
                 try:
@@ -583,7 +583,7 @@ class Dictionary(basic.Property):
         value = out
         if not self.observe_mutations:
             return value
-        value = OBSERVABLE[self._class_default](value)
+        value = OBSERVABLE[self._class_container](value)
         value._name = self.name
         value._instance = instance
         return value
@@ -645,7 +645,7 @@ class Dictionary(basic.Property):
         except TypeError as err:
             raise TypeError('Dictionary property {} cannot be deserialized - '
                             'keys contain {}'.format(self.name, err))
-        return self._class_default(output_dict)
+        return self._class_container(output_dict)
 
     def equal(self, value_a, value_b):
         try:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -58,7 +58,7 @@ class TestContainer(unittest.TestCase):
         assert HasDummyTuple()._props['mytuple'].prop.name == 'mytuple'
 
         class HasIntTuple(properties.HasProperties):
-            aaa = properties.Tuple('tuple of ints', properties.Integer(''))
+            aaa = properties.Tuple('tuple of ints', properties.Integer(''), default=tuple)
 
         li = HasIntTuple()
         li.aaa = (1, 2, 3)
@@ -266,7 +266,7 @@ class TestContainer(unittest.TestCase):
 
         class HasIntList(properties.HasProperties):
             aaa = properties.List('list of ints', properties.Integer(''),
-                                  observe_mutations=om)
+                                  observe_mutations=om, default=list)
 
         li = HasIntList()
         li.aaa = [1, 2, 3]
@@ -477,7 +477,7 @@ class TestContainer(unittest.TestCase):
 
         class HasIntSet(properties.HasProperties):
             aaa = properties.Set('set of ints', properties.Integer(''),
-                                  observe_mutations=om)
+                                  observe_mutations=om, default=set)
 
         li = HasIntSet()
         li.aaa = {1, 2, 3}
@@ -885,7 +885,7 @@ class TestContainer(unittest.TestCase):
         assert HasDummyDict()._props['mydict'].value_prop.name == 'mydict'
 
         class HasDict(properties.HasProperties):
-            aaa = properties.Dictionary('dictionary')
+            aaa = properties.Dictionary('dictionary', default=dict)
 
         li = HasDict()
         li.aaa = {1: 2}

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -246,7 +246,7 @@ class TestDefault(unittest.TestCase):
         assert isinstance(hi2.inst, HasIntSubclass)
 
         class HasList(properties.HasProperties):
-            z = properties.List('z list', HasInstance)
+            z = properties.List('z list', HasInstance, default=list)
 
         hl0 = HasList()
         hl1 = HasList()
@@ -256,8 +256,12 @@ class TestDefault(unittest.TestCase):
         assert hl0.z is not hl1.z
 
     def test_list_default(self):
+
+        class ListDefault(properties.List):
+            _class_default = list
+
         class HasIntList(properties.HasProperties):
-            intlist = properties.List('list of ints', properties.Integer(''))
+            intlist = ListDefault('list of ints', properties.Integer(''))
 
         hil = HasIntList()
 


### PR DESCRIPTION
Using empty containers as defaults caused big problems and was not consistent with the rest of `properties` (see #169). This PR is not backwards compatible, but I think it is the right choice.