### PR TITLE
Non-standard container classes are now maintained

### DIFF
--- a/docs/content/container.rst
+++ b/docs/content/container.rst
@@ -23,11 +23,7 @@ Dictionary
 
 .. autoclass:: properties.Dictionary
 
-Custom Containers
------------------
+Observable Container Creation
+-----------------------------
 
-.. autoclass:: properties.base.containers.PropertiesList
-
-.. autoclass:: properties.base.containers.PropertiesSet
-
-.. autoclass:: properties.base.containers.PropertiesDict
+.. autofunction:: properties.base.containers.observable_copy

--- a/properties/base/containers.py
+++ b/properties/base/containers.py
@@ -540,6 +540,17 @@ class Dictionary(basic.Property):
         self._name = value
 
     @property
+    def coerce(self):
+        """Coerce sets/lists to tuples or other inputs to length-1 tuples"""
+        return getattr(self, '_coerce', False)
+
+    @coerce.setter
+    def coerce(self, value):
+        if not isinstance(value, bool):
+            raise TypeError('coerce must be a boolean')
+        self._coerce = value
+
+    @property
     def info(self):
         """Supplemental description of the list, with length and type"""
         itext = self.class_info
@@ -554,8 +565,13 @@ class Dictionary(basic.Property):
         return itext
 
     def validate(self, instance, value):
-        if not isinstance(value, self._class_container):
+        if not self.coerce and not isinstance(value, self._class_container):
             self.error(instance, value)
+        if self.coerce:
+            try:
+                value = self._class_container(value)
+            except TypeError:
+                self.error(instance, value)
         out = value.__class__()
         for key, val in iteritems(value):
             if self.key_prop:

--- a/properties/base/containers.py
+++ b/properties/base/containers.py
@@ -380,7 +380,7 @@ class List(Tuple):
     * **observe_mutations** - If False, the underlying storage class is
       a :code:`list` (or subclass thereof). If True, the underlying storage
       class will be an
-      :function:`observable_copy <properties.base.containers.observable_copy>`
+      :func:`observable_copy <properties.base.containers.observable_copy>`
       of the list. The benefit of observing mutations is that all mutations
       and operations will trigger HasProperties change notifications. The
       drawback is slower performance as copies of the list are made on
@@ -437,7 +437,7 @@ class Set(List):
     * **observe_mutations** - If False, the underlying storage class is
       a :code:`set` (or subclass thereof). If True, the underlying storage
       class will be an
-      :function:`observable_copy <properties.base.containers.observable_copy>`
+      :func:`observable_copy <properties.base.containers.observable_copy>`
       of the set. The benefit of observing mutations is that all mutations
       and operations will trigger HasProperties change notifications. The
       drawback is slower performance as copies of the set are made on
@@ -488,7 +488,7 @@ class Dictionary(basic.Property):
     * **observe_mutations** - If False, the underlying storage class is
       a :code:`dict` (or subclass thereof). If True, the underlying storage
       class will be an
-      :function:`observable_copy <properties.base.containers.observable_copy>`
+      :func:`observable_copy <properties.base.containers.observable_copy>`
       of the dict. The benefit of observing mutations is that all mutations
       and operations will trigger HasProperties change notifications. The
       drawback is slower performance as copies of the dict are made on

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -928,6 +928,19 @@ class TestContainer(unittest.TestCase):
             hfd.mydict.update({1: HasInt(myint=1)})
             hfd.validate()
 
+        class HasCoercedDict(properties.HasProperties):
+            my_coerced_dict = properties.Dictionary('my dict', coerce=True)
+            my_uncoerced_dict = properties.Dictionary('my dict')
+
+        key_val_list = [('a', 1), ('b', 2), ('c', 3)]
+
+        hcd = HasCoercedDict()
+        with self.assertRaises(ValueError):
+            hcd.my_uncoerced_dict = key_val_list
+
+        hcd.my_coerced_dict = key_val_list
+        assert hcd.my_coerced_dict == {'a': 1, 'b': 2, 'c': 3}
+
     def test_nested_observed(self):
         self._test_nested_observed(True)
         self._test_nested_observed(False)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from collections import OrderedDict
 import unittest
 
 import numpy as np
@@ -927,6 +928,81 @@ class TestContainer(unittest.TestCase):
             hfd.mydict.update({1: HasInt(myint=1)})
             hfd.validate()
 
+    def test_nested_observed(self):
+        self._test_nested_observed(True)
+        self._test_nested_observed(False)
+
+    def _test_nested_observed(self, om):
+
+        class HasNestedList(properties.HasProperties):
+
+            nested_list = properties.List(
+                'This is not a great idea...',
+                properties.List('',
+                    properties.Integer(''),
+                    observe_mutations=True
+                ),
+                observe_mutations=om,
+            )
+
+        hnl = HasNestedList()
+
+        hnl.nested_list = [[1, 2, 3], [4, 5, 6]]
+        assert hnl.nested_list == [[1, 2, 3], [4, 5, 6]]
+        hnl.nested_list[0][0] = 10
+        assert hnl.nested_list == [[10, 2, 3], [4, 5, 6]]
+        hnl.nested_list += [[7, 8, 9]]
+        assert hnl.nested_list == [[10, 2, 3], [4, 5, 6], [7, 8, 9]]
+        hnl.nested_list[0] += [0]
+        assert hnl.nested_list == [[10, 2, 3, 0], [4, 5, 6], [7, 8, 9]]
+
+    def test_container_class_retention(self):
+
+        class HasCollections(properties.HasProperties):
+            tuple_unobs = properties.Tuple('')
+            dict_unobs = properties.Dictionary('')
+            dict_obs = properties.Dictionary('', observe_mutations=True)
+            list_unobs = properties.List('')
+            list_obs = properties.List('', observe_mutations=True)
+            set_unobs = properties.Set('')
+            set_obs = properties.Set('', observe_mutations=True)
+
+        class SillyTuple(tuple):
+            pass
+
+        class SillyList(list):
+            pass
+
+        class SillySet(set):
+            pass
+
+        hc = HasCollections()
+        hc.tuple_unobs = SillyTuple([1, 2, 3])
+        assert isinstance(hc.tuple_unobs, SillyTuple)
+        hc.dict_unobs = OrderedDict()
+        assert isinstance(hc.dict_unobs, OrderedDict)
+        hc.dict_unobs['a'] = 1
+        assert isinstance(hc.dict_unobs, OrderedDict)
+        hc.dict_obs = OrderedDict()
+        assert isinstance(hc.dict_obs, OrderedDict)
+        hc.dict_obs['a'] = 1
+        assert isinstance(hc.dict_obs, OrderedDict)
+        hc.list_unobs = SillyList()
+        assert isinstance(hc.list_unobs, SillyList)
+        hc.list_unobs += [1]
+        assert isinstance(hc.list_unobs, SillyList)
+        hc.list_obs = SillyList([1])
+        assert isinstance(hc.list_obs, SillyList)
+        hc.list_obs[0] = 0
+        assert isinstance(hc.list_obs, SillyList)
+        hc.set_unobs = SillySet([0])
+        assert isinstance(hc.set_unobs, SillySet)
+        hc.set_unobs |= set([1])
+        assert isinstance(hc.set_unobs, SillySet)
+        hc.set_obs = SillySet()
+        assert isinstance(hc.set_obs, SillySet)
+        hc.set_obs.add(1)
+        assert isinstance(hc.set_obs, SillySet)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For example, previously if you used an `OrderedDict` for a `properties.Dictionary`, it would be coerced to a `dict`. Now, these classes are maintained.

Container classes still do not allow duck-typing - i.e. you still have to use a subclass of `dict`, not just something that implements `__getitem__`, `__setitem__`, etc.

This addresses @bsmithyman's comment here: https://github.com/aranzgeo/properties/pull/188#pullrequestreview-87918784