### PR TITLE
Fix bugs that arise from deserializing dicts with Unions of Instance properties

### DIFF
--- a/properties/base/union.py
+++ b/properties/base/union.py
@@ -86,6 +86,12 @@ class Union(basic.Property):
 
     @property
     def strict_instances(self):
+        """Require input dictionaries for instances to be valid
+
+        If True (the default), this passes
+        :code:`strict=True, assert_valid=True` to the instance
+        deserializer.
+        """
         return getattr(self, '_strict_instances', True)
 
     @strict_instances.setter

--- a/properties/base/union.py
+++ b/properties/base/union.py
@@ -85,6 +85,16 @@ class Union(basic.Property):
         self._props = new_props
 
     @property
+    def strict_instances(self):
+        return getattr(self, '_strict_instances', True)
+
+    @strict_instances.setter
+    def strict_instances(self, value):
+        if not isinstance(value, bool):
+            raise TypeError('strict_instances must be a boolean')
+        self._strict_instances = value
+
+    @property
     def info(self):
         """Description of the property, supplemental to the basic doc"""
         return ' or '.join([p.info or 'any value' for p in self.props])
@@ -205,6 +215,22 @@ class Union(basic.Property):
             return self.deserializer(value, **kwargs)
         if value is None:
             return None
+        instance_props = [
+            prop for prop in self.props if isinstance(prop, Instance)
+        ]
+        kwargs = kwargs.copy()
+        kwargs.update({
+            'strict': kwargs.get('strict') or self.strict_instances,
+            'assert_valid': self.strict_instances,
+        })
+        if isinstance(value, dict) and value.get('__class__'):
+            clsname = value.get('__class__')
+            for prop in instance_props:
+                if clsname == prop.instance_class.__name__:
+                    try:
+                        return prop.deserialize(value, **kwargs)
+                    except GENERIC_ERRORS:
+                        continue
         for prop in self.props:
             try:
                 return prop.deserialize(value, **kwargs)

--- a/properties/base/union.py
+++ b/properties/base/union.py
@@ -233,10 +233,7 @@ class Union(basic.Property):
             clsname = value.get('__class__')
             for prop in instance_props:
                 if clsname == prop.instance_class.__name__:
-                    try:
-                        return prop.deserialize(value, **kwargs)
-                    except GENERIC_ERRORS:
-                        continue
+                    return prop.deserialize(value, **kwargs)
         for prop in self.props:
             try:
                 return prop.deserialize(value, **kwargs)

--- a/properties/extras/singleton.py
+++ b/properties/extras/singleton.py
@@ -53,7 +53,8 @@ class Singleton(six.with_metaclass(SingletonMetaclass, HasProperties)):
         return json_dict
 
     @classmethod
-    def deserialize(cls, value, trusted=False, verbose=True, **kwargs):
+    def deserialize(cls, value, trusted=False, strict=False,
+                    assert_valid=False, **kwargs):
         """Create a Singleton instance from a serialized dictionary.
 
         This behaves identically to HasProperties.deserialize, except if
@@ -78,7 +79,8 @@ class Singleton(six.with_metaclass(SingletonMetaclass, HasProperties)):
         newinst = super(Singleton, cls).deserialize(
             value,
             trusted=trusted,
-            verbose=verbose,
+            strict=strict,
+            assert_valid=assert_valid,
             **kwargs
         )
         if name:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import pickle
 import unittest
-import warnings
 
 import numpy as np
 
@@ -63,30 +62,20 @@ class TestSerialization(unittest.TestCase):
         assert hp3.serialize() == hp3_dict
         assert hp3.serialize(include_class=False) == hp3_dict_no_class
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            assert not isinstance(
-                properties.HasProperties.deserialize(hp3_dict), HP3
-            )
-            assert len(w) == 1
-            assert issubclass(w[0].category, RuntimeWarning)
-            assert not isinstance(
-                properties.HasProperties.deserialize(hp3_dict_no_class), HP3
-            )
-            assert len(w) == 2
-            assert issubclass(w[1].category, RuntimeWarning)
-            assert not isinstance(
-                properties.HasProperties.deserialize(
-                    hp3_dict_no_class, trusted=True
-                ), HP3
-            )
-            assert len(w) == 3
-            assert issubclass(w[2].category, RuntimeWarning)
-            assert isinstance(properties.HasProperties.deserialize(
-                {'__class__': 'HP9'}, trusted=True
-            ), properties.HasProperties)
-            assert len(w) == 4
-            assert issubclass(w[3].category, RuntimeWarning)
+        assert not isinstance(
+            properties.HasProperties.deserialize(hp3_dict), HP3
+        )
+        assert not isinstance(
+            properties.HasProperties.deserialize(hp3_dict_no_class), HP3
+        )
+        assert not isinstance(
+            properties.HasProperties.deserialize(
+                hp3_dict_no_class, trusted=True
+            ), HP3
+        )
+        assert isinstance(properties.HasProperties.deserialize(
+            {'__class__': 'HP9'}, trusted=True
+        ), properties.HasProperties)
 
         assert isinstance(HP3.deserialize(hp3_dict), HP3)
         assert isinstance(HP3.deserialize(hp3_dict_no_class), HP3)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -140,6 +140,15 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(properties.ValidationError):
             HP3.deserialize(hp3_subextra, strict=True)
 
+        class Invalid(properties.HasProperties):
+
+            def validate(self):
+                return False
+
+        assert isinstance(Invalid.deserialize({}), Invalid)
+        with self.assertRaises(properties.ValidationError):
+            Invalid.deserialize({}, assert_valid=True)
+
 
     def test_immutable_serial(self):
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -48,16 +48,16 @@ class TestSerialization(unittest.TestCase):
                 '__class__': 'HP2',
                 'inst1': {
                     '__class__': 'HP1',
-                    'a': 10
-                }
-            }
+                    'a': 10,
+                },
+            },
         }
         hp3_dict_no_class = {
             'inst2': {
                 'inst1': {
-                    'a': 10
-                }
-            }
+                    'a': 10,
+                },
+            },
         }
 
         assert hp3.serialize() == hp3_dict
@@ -96,6 +96,61 @@ class TestSerialization(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             HP1.deserialize(5)
+
+        with self.assertRaises(properties.ValidationError):
+            properties.HasProperties.deserialize(hp3_dict, strict=True)
+        assert isinstance(
+            HP3.deserialize(hp3_dict, strict=True), HP3
+        )
+        hp3_extra = {
+            '__class__': 'HP3',
+            'inst2': {
+                '__class__': 'HP2',
+                'inst1': {
+                    '__class__': 'HP1',
+                    'a': 10,
+                }
+            },
+            'b': 1,
+        }
+        with self.assertRaises(properties.ValidationError):
+            HP3.deserialize(hp3_extra, strict=True)
+        assert isinstance(HP3.deserialize({}), HP3)
+        with self.assertRaises(properties.ValidationError):
+            HP3.deserialize({}).validate()
+        with self.assertRaises(properties.ValidationError):
+            HP3.deserialize({}, assert_valid=True)
+
+        hp3_incomplete = {
+            '__class__': 'HP3',
+            'inst2': {
+                '__class__': 'HP2',
+                'inst1': {
+                    '__class__': 'HP1',
+                }
+            }
+        }
+
+        assert isinstance(HP3.deserialize(hp3_incomplete, strict=True), HP3)
+        with self.assertRaises(properties.ValidationError):
+            HP3.deserialize(hp3_incomplete, assert_valid=True)
+
+        hp3_subextra = {
+            '__class__': 'HP3',
+            'inst2': {
+                '__class__': 'HP2',
+                'inst1': {
+                    '__class__': 'HP1',
+                    'a': 10,
+                    'b': 2,
+                }
+            }
+        }
+
+        assert isinstance(HP3.deserialize(hp3_subextra, assert_valid=True), HP3)
+        with self.assertRaises(properties.ValidationError):
+            HP3.deserialize(hp3_subextra, strict=True)
+
 
     def test_immutable_serial(self):
 
@@ -231,6 +286,8 @@ class TestSerialization(unittest.TestCase):
         assert isinstance(many.mylist[0], HP1)
         assert many.mylist[0].a == 6
         assert many.myunion == '1PH'
+
+        assert isinstance(ManyProperties.deserialize({'mystr': 'hi'}), ManyProperties)
 
     def test_dynamic_serial(self):
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -145,10 +145,27 @@ class TestUnion(unittest.TestCase):
                 props=[SomeProps, DifferentProps],
             )
 
-        dp = {'c': 1, 'd': 2}
+        dp = {'u': {'c': 1, 'd': 2}}
 
         uu = UnambigousUnion.deserialize(dp)
         assert isinstance(uu.u, DifferentProps)
+
+        class AmbiguousUnion(properties.HasProperties):
+
+            u = properties.Union(
+                doc='ambiguous',
+                props=[SomeProps, SameProps],
+            )
+
+        sp = {'u': {'a': 1, 'b': 2}}
+
+        au = AmbiguousUnion.deserialize(sp)
+        assert isinstance(au.u, SomeProps)
+
+        sp.update({'__class__': 'SameProps'})
+
+        au = AmbiguousUnion.deserialize(sp)
+        assert isinstance(au.u, SameProps)
 
 
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -121,6 +121,37 @@ class TestUnion(unittest.TestCase):
         with self.assertRaises(ValueError):
             hou.validate()
 
+    def test_union_deserialization(self):
+
+        class SomeProps(properties.HasProperties):
+
+            a = properties.Integer('')
+            b = properties.Integer('')
+
+        class SameProps(properties.HasProperties):
+
+            a = properties.Integer('')
+            b = properties.Integer('')
+
+        class DifferentProps(properties.HasProperties):
+
+            c = properties.Integer('')
+            d = properties.Integer('')
+
+        class UnambigousUnion(properties.HasProperties):
+
+            u = properties.Union(
+                doc='unambiguous',
+                props=[SomeProps, DifferentProps],
+            )
+
+        dp = {'c': 1, 'd': 2}
+
+        uu = UnambigousUnion.deserialize(dp)
+        assert isinstance(uu.u, DifferentProps)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Deserializing when a `Union` of `Instance` properties is present results in unwanted behavior. `'__class__'` was ignored even when that class was a valid choice, and dictionaries were filtered to be empty to match one class, rather than selecting a different class.

Now, `deserialize` has additional kwargs:
- `strict` - this requires `__class__` to match the deserialized instance AND disallows extra properties in the input dictionary
- `assert_valid` - deserialization fails if the resulting instance is invalid.

To maintain backwards compatibility, both of these are `False` by default, but to fix the above `Union` bugs, they are `True` by default when deserializing the `Union` property. You can keep the current, lenient behavior of `Union` properties by setting `strict_instances=True` on the `Union` property.